### PR TITLE
Don't try to decode bodies that don't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ example:
 	cd $(BUILD_PATH)/example && go build -a -o $(EXAMPLE) *.go
 
 test:
-	cd $(BUILD_PATH) && go test -race 
+	cd $(BUILD_PATH) && go test -race
 
 clean:
 	rm -f $(EXAMPLE_BIN)

--- a/body.go
+++ b/body.go
@@ -72,6 +72,8 @@ func ReadRequest(req *http.Request, v interface{}) error {
 			return NewError(nil, EcodeDeserializationFailed, err)
 		}
 		return nil
+	case "":
+		return nil
 	default:
 		return NewError(nil, EcodeUnsupportedMediaType, ct)
 	}


### PR DESCRIPTION
Although it is rare it is valid to send `PUT` and `POST` requests with no body. In this case the `Content-Type` header typically doesn't exist and we should handle w/o failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite/56)
<!-- Reviewable:end -->
