### PR TITLE
Force Content-Type header for YAML schema files

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -3,7 +3,9 @@ package luddite
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"strconv"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -25,12 +27,19 @@ func (h *SchemaHandler) ServeHTTP(rw http.ResponseWriter, req0 *http.Request, pa
 		return
 	}
 
-	file := fmt.Sprintf("/v%d/%s", version, params.ByName("filepath"))
+	filepath := params.ByName("filepath")
+	file := fmt.Sprintf("/v%d/%s", version, filepath)
 	req1, err := http.NewRequest("GET", file, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	rw.Header().Del(HeaderContentType)
+	switch strings.ToLower(path.Ext(filepath)) {
+	case ".yaml", ".yml":
+		rw.Header().Set(HeaderContentType, ContentTypeOctetStream)
+	default:
+		rw.Header().Del(HeaderContentType)
+	}
+
 	h.fileServer.ServeHTTP(rw, req1)
 }


### PR DESCRIPTION
* `Content-Type` is otherwise set to `text/plain` by the Golang file server and this messes up the Swagger UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite/57)
<!-- Reviewable:end -->
