### PR TITLE
Fixed api-standards.md reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ makes it easy to implement services that comply with the
 [Orion REST API Standards][apistds].
 
 [golang]: http://golang.org/
-[apistds]: https://github.com/SpirentOrion/orion-docs/blob/master/api/api-standards.md
+[apistds]: https://github.com/SpirentOrion/orion-api/blob/master/doc/api/api-standards.md
 
 To run the example service:
 


### PR DESCRIPTION
Minor tweak while reading some token/licensing stuff. Will vendor into orion-api (along with a few doc fixes there too) after this is committed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite/65)
<!-- Reviewable:end -->
