### PR TITLE
Allow resource handlers to completely handle their own responses

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -57,9 +57,10 @@ type Resource interface {
 func AddListRoute(router *httprouter.Router, basePath string, r Resource) {
 	router.GET(basePath, func(rw http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		SetContextRequestProgress(req.Context(), "luddite", "Router.List", "begin")
-		status, v := r.List(req)
-		SetContextRequestProgress(req.Context(), "luddite", "Router.List", "write")
-		WriteResponse(rw, status, v)
+		if status, v := r.List(req); status > 0 {
+			SetContextRequestProgress(req.Context(), "luddite", "Router.List", "write")
+			WriteResponse(rw, status, v)
+		}
 	})
 }
 
@@ -73,9 +74,10 @@ func AddGetRoute(router *httprouter.Router, basePath string, withId bool, r Reso
 	router.GET(itemPath, func(rw http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		id := params.ByName("id")
 		SetContextRequestProgress(req.Context(), "luddite", "Router.Get", "begin")
-		status, v := r.Get(req, id)
-		SetContextRequestProgress(req.Context(), "luddite", "Router.Get", "write")
-		WriteResponse(rw, status, v)
+		if status, v := r.Get(req, id); status > 0 {
+			SetContextRequestProgress(req.Context(), "luddite", "Router.Get", "write")
+			WriteResponse(rw, status, v)
+		}
 	})
 }
 
@@ -87,17 +89,18 @@ func AddCreateRoute(router *httprouter.Router, basePath string, r Resource) {
 			return
 		}
 		SetContextRequestProgress(req.Context(), "luddite", "Router.Create", "begin")
-		status, v1 := r.Create(req, v0)
-		if status == http.StatusCreated {
-			url := url.URL{
-				Scheme: req.URL.Scheme,
-				Host:   req.URL.Host,
-				Path:   path.Join(basePath, r.Id(v1)),
+		if status, v1 := r.Create(req, v0); status > 0 {
+			if status == http.StatusCreated {
+				url := url.URL{
+					Scheme: req.URL.Scheme,
+					Host:   req.URL.Host,
+					Path:   path.Join(basePath, r.Id(v1)),
+				}
+				rw.Header().Add(HeaderLocation, url.String())
 			}
-			rw.Header().Add(HeaderLocation, url.String())
+			SetContextRequestProgress(req.Context(), "luddite", "Router.Create", "write")
+			WriteResponse(rw, status, v1)
 		}
-		SetContextRequestProgress(req.Context(), "luddite", "Router.Create", "write")
-		WriteResponse(rw, status, v1)
 	})
 }
 
@@ -120,9 +123,10 @@ func AddUpdateRoute(router *httprouter.Router, basePath string, withId bool, r R
 			return
 		}
 		SetContextRequestProgress(req.Context(), "luddite", "Router.Update", "begin")
-		status, v1 := r.Update(req, id, v0)
-		SetContextRequestProgress(req.Context(), "luddite", "Router.Update", "write")
-		WriteResponse(rw, status, v1)
+		if status, v1 := r.Update(req, id, v0); status > 0 {
+			SetContextRequestProgress(req.Context(), "luddite", "Router.Update", "write")
+			WriteResponse(rw, status, v1)
+		}
 	})
 }
 
@@ -136,9 +140,10 @@ func AddDeleteRoute(router *httprouter.Router, basePath string, withId bool, r R
 	router.DELETE(itemPath, func(rw http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		id := params.ByName("id")
 		SetContextRequestProgress(req.Context(), "luddite", "Router.Delete", "begin")
-		status, v := r.Delete(req, id)
-		SetContextRequestProgress(req.Context(), "luddite", "Router.Delete", "write")
-		WriteResponse(rw, status, v)
+		if status, v := r.Delete(req, id); status > 0 {
+			SetContextRequestProgress(req.Context(), "luddite", "Router.Delete", "write")
+			WriteResponse(rw, status, v)
+		}
 	})
 }
 
@@ -156,9 +161,10 @@ func AddActionRoute(router *httprouter.Router, basePath string, withId bool, r R
 		}
 		action := params.ByName("action")
 		SetContextRequestProgress(req.Context(), "luddite", "Router.Action", "begin")
-		status, v := r.Action(req, id, action)
-		SetContextRequestProgress(req.Context(), "luddite", "Router.Action", "write")
-		WriteResponse(rw, status, v)
+		if status, v := r.Action(req, id, action); status > 0 {
+			SetContextRequestProgress(req.Context(), "luddite", "Router.Action", "write")
+			WriteResponse(rw, status, v)
+		}
 	})
 }
 


### PR DESCRIPTION
Since #64 resource handlers have been exposed to `http.ResponseWriter` objects
and this allows them to return response bodies as necessary. However, when this
happens, `luddite`-level handler wrappers still call `WriteResponse` and this
ultimately leads to output in the standard error log:

```
2017/11/13 08:50:27 http: multiple response.WriteHeader calls
```

This change allows resource handlers to signal that they've handled the complete
response. If they return an HTTP status <= 0 then `luddite` won't otherwise try
to deal with the response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite/66)
<!-- Reviewable:end -->
