### PR TITLE
Allow prepending middleware handlers

### DIFF
--- a/v3/body.go
+++ b/v3/body.go
@@ -16,6 +16,7 @@ const (
 	ContentTypeCss               = "text/css"
 	ContentTypeCsv               = "text/csv"
 	ContentTypeGif               = "image/gif"
+	ContentTypeGrpc              = "application/grpc"
 	ContentTypeHtml              = "text/html"
 	ContentTypeJson              = "application/json"
 	ContentTypeMsgpack           = "application/msgpack"

--- a/v3/service.go
+++ b/v3/service.go
@@ -165,10 +165,22 @@ func (s *Service) Router(version int) (*httptreemux.ContextMux, error) {
 	return router, nil
 }
 
-// AddHandler adds a middleware handler to the service's middleware stack. All
-// handlers must be added before Run is called.
-func (s *Service) AddHandler(h Handler) {
+// AppendHandler appends a middleware handler to the service's middleware stack.
+// All handlers must be added before Run is called.
+func (s *Service) AppendHandler(h Handler) {
 	s.handlers = append(s.handlers, h)
+}
+
+// PrependHandler prepends a middleware handler to the service's middleware
+// stack. All handlers must be added before Run is called.
+func (s *Service) PrependHandler(h Handler) {
+	s.handlers = append([]Handler{h}, s.handlers...)
+}
+
+// AddHandler forwards to AppendHandler. It is provided for backward
+// compatibility.
+func (s *Service) AddHandler(h Handler) {
+	s.AppendHandler(h)
 }
 
 // AddResource is a convenience method that performs runtime type assertions on


### PR DESCRIPTION
* This is required to support gRPC, which must get a crack at incoming requests
  before the bottom handler.

* Also added Content-Type constant for gRPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/luddite/73)
<!-- Reviewable:end -->
