### PR TITLE
Hook to skip access log entry

### DIFF
--- a/v3/context.go
+++ b/v3/context.go
@@ -21,6 +21,7 @@ type handlerDetails struct {
 	requestProgress string
 	apiVersion      int
 	callerId        string
+	skipInfoLog     bool
 	details         map[interface{}]interface{}
 }
 
@@ -32,6 +33,7 @@ func (d *handlerDetails) init(s *Service, rw ResponseWriter, request *http.Reque
 	d.requestProgress = requestProgress
 	d.apiVersion = 0
 	d.callerId = ""
+	d.skipInfoLog = false
 	d.details = nil
 }
 
@@ -141,6 +143,15 @@ func ContextApiVersion(ctx context.Context) (apiVersion int) {
 func SetContextCallerId(ctx context.Context, callerId string) {
 	if d, ok := ctx.Value(contextHandlerDetailsKey).(*handlerDetails); ok {
 		d.callerId = callerId
+	}
+}
+
+// SetContextSkipInfoLog sets a request-specific flag in a context.Context. If
+// set, the request's access log entry and trace data will be skipped at
+// InfoLevel if request was successful. Errors will always be logged.
+func SetContextSkipInfoLog(ctx context.Context) {
+	if d, ok := ctx.Value(contextHandlerDetailsKey).(*handlerDetails); ok {
+		d.skipInfoLog = true
 	}
 }
 


### PR DESCRIPTION
Service endpoints can invoke this method per request to skip access log entry at Info level if request was successful (errors are always logged). This is to reduce noise in the logs from frequently invoked methods that have no diagnostic value.