### PR TITLE
TMV-2752 - fix CRLF in luddite

### DIFF
--- a/v3/body.go
+++ b/v3/body.go
@@ -149,12 +149,12 @@ func WriteResponse(rw http.ResponseWriter, status int, v interface{}) (err error
 			case []byte:
 				b = v.([]byte)
 				if ct == "" {
-					rw.Header().Set(HeaderContentType, ContentTypeOctetStream)
+					SetHeader(rw, HeaderContentType, ContentTypeOctetStream)
 				}
 			case string:
 				b = []byte(v.(string))
 				if ct == "" {
-					rw.Header().Set(HeaderContentType, ContentTypePlain)
+					SetHeader(rw, HeaderContentType, ContentTypePlain)
 				}
 			default:
 				rw.WriteHeader(http.StatusNotAcceptable)

--- a/v3/body_test.go
+++ b/v3/body_test.go
@@ -68,7 +68,7 @@ func TestWriteJson(t *testing.T) {
 	}
 
 	rw := httptest.NewRecorder()
-	rw.Header().Add(HeaderContentType, ContentTypeJson)
+	AddHeader(rw, HeaderContentType, ContentTypeJson)
 
 	if err := WriteResponse(rw, http.StatusOK, s); err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func TestWriteXml(t *testing.T) {
 	}
 
 	rw := httptest.NewRecorder()
-	rw.Header().Add(HeaderContentType, ContentTypeXml)
+	AddHeader(rw, HeaderContentType, ContentTypeXml)
 
 	if err := WriteResponse(rw, http.StatusOK, s); err != nil {
 		t.Fatal(err)
@@ -145,7 +145,7 @@ func TestWriteXml(t *testing.T) {
 func TestWriteHtml(t *testing.T) {
 	// Write []byte
 	rw := httptest.NewRecorder()
-	rw.Header().Add(HeaderContentType, ContentTypeHtml)
+	AddHeader(rw, HeaderContentType, ContentTypeHtml)
 
 	if err := WriteResponse(rw, http.StatusOK, []byte(sampleData)); err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestWriteHtml(t *testing.T) {
 
 	// Write string
 	rw = httptest.NewRecorder()
-	rw.Header().Add(HeaderContentType, ContentTypeHtml)
+	AddHeader(rw, HeaderContentType, ContentTypeHtml)
 
 	if err := WriteResponse(rw, http.StatusOK, sampleData); err != nil {
 		t.Fatal(err)
@@ -193,7 +193,7 @@ func TestWriteHtml(t *testing.T) {
 	}
 
 	rw = httptest.NewRecorder()
-	rw.Header().Add(HeaderContentType, ContentTypeHtml)
+	AddHeader(rw, HeaderContentType, ContentTypeHtml)
 
 	if err := WriteResponse(rw, http.StatusOK, s); err != nil {
 		t.Fatal(err)

--- a/v3/bottom.go
+++ b/v3/bottom.go
@@ -64,7 +64,7 @@ func (b *bottomHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request, nex
 	defer serverSpan.Finish()
 
 	requestId := strconv.FormatUint(b.tracerKind.TraceId(serverSpan), 10)
-	rw.Header().Set(HeaderRequestId, requestId)
+	SetHeader(rw, HeaderRequestId, requestId)
 
 	// Create a new response writer
 	res = responseWriterPool.Get().(*responseWriter)

--- a/v3/header.go
+++ b/v3/header.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -85,4 +86,25 @@ func RequestQueryCursor(r *http.Request) string {
 // the http.Request.
 func RequestResourceNonce(r *http.Request) string {
 	return r.Header.Get(HeaderSpirentResourceNonce)
+}
+
+// SetHeader sets the header key with sanitized value to a http response writer
+func SetHeader(rw http.ResponseWriter, key string, value string) {
+	// remove /r/n(CRLF) to avoid http response splitting
+	sanitizedString := sanitizeString(value)
+	rw.Header().Set(key, sanitizedString)
+}
+
+// AddHeader adds the header key with sanitized value to a http response writer
+func AddHeader(rw http.ResponseWriter, key string, value string) {
+	// remove /r/n(CRLF) to avoid http response splitting
+	sanitizedString := sanitizeString(value)
+	rw.Header().Add(key, sanitizedString)
+}
+
+// sanitizeString removes "/r/n"(CRLF) to avoid http response splitting
+func sanitizeString(value string) (sanitizedString string) {
+	sanitizedString = strings.ReplaceAll(value, "\r", "")
+	sanitizedString = strings.ReplaceAll(sanitizedString, "\n", "")
+	return
 }

--- a/v3/negotiator.go
+++ b/v3/negotiator.go
@@ -40,7 +40,7 @@ func (n *negotiatorHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request,
 	// the resource handler doesn't deal with it, then we can expect a 406
 	// from WriteResponse.
 	if format, _ := negotiation.NegotiateAccept(accept, acceptedContentTypes); format != nil {
-		rw.Header().Set(HeaderContentType, format.Value)
+		SetHeader(rw, HeaderContentType, format.Value)
 	}
 
 	// If the X-Spirent-Inhibit-Response header is set and true-ish, then
@@ -49,7 +49,7 @@ func (n *negotiatorHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request,
 	// makes the behavior obvious to clients (i.e. response header shows
 	// intention beyond the 204 status).
 	if inhibitResp, _ := strconv.ParseBool(req.Header.Get(HeaderSpirentInhibitResponse)); inhibitResp {
-		rw.Header().Set(HeaderSpirentInhibitResponse, "1")
+		SetHeader(rw, HeaderSpirentInhibitResponse, "1")
 	}
 
 	next(rw, req)

--- a/v3/resource.go
+++ b/v3/resource.go
@@ -105,7 +105,7 @@ func AddCreateCollectionRoute(router *httptreemux.ContextMux, basePath string, r
 					Host:   req.URL.Host,
 					Path:   path.Join(req.URL.Path, r.Id(v1)),
 				}
-				rw.Header().Add(HeaderLocation, url.String())
+				AddHeader(rw, HeaderLocation, url.String())
 			}
 			SetContextRequestProgress(ctx, "luddite.CreateCollectionRoute.write")
 			_ = WriteResponse(rw, status, v1)

--- a/v3/schema.go
+++ b/v3/schema.go
@@ -44,7 +44,7 @@ func (h *schemaHandler) ServeHTTP(rw http.ResponseWriter, req0 *http.Request) {
 
 	switch strings.ToLower(path.Ext(filepath)) {
 	case ".yaml", ".yml":
-		rw.Header().Set(HeaderContentType, ContentTypeOctetStream)
+		SetHeader(rw, HeaderContentType, ContentTypeOctetStream)
 	default:
 		rw.Header().Del(HeaderContentType)
 	}

--- a/v3/schema_test.go
+++ b/v3/schema_test.go
@@ -28,7 +28,7 @@ func TestSchemaHandlerDefaultContentType(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req = req.WithContext(ctx)
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	s := newSchemaHandler(fakeFS)
 	s.ServeHTTP(rw, req)
@@ -53,7 +53,7 @@ func TestSchemaHandlerOctetStreamContentType(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req = req.WithContext(ctx)
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	s := newSchemaHandler(fakeFS)
 	s.ServeHTTP(rw, req)
@@ -74,7 +74,7 @@ func TestSchemaHandlerGivenInvalidVersionStringLength(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req = req.WithContext(ctx)
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	s := newSchemaHandler(nil)
 	s.ServeHTTP(rw, req)
@@ -91,7 +91,7 @@ func TestSchemaHandlerGivenInvalidVersionValue(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req = req.WithContext(ctx)
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	s := newSchemaHandler(nil)
 	s.ServeHTTP(rw, req)
@@ -108,7 +108,7 @@ func TestSchemaHandlerGivenInvalidVersionNumber(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req = req.WithContext(ctx)
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	s := newSchemaHandler(nil)
 	s.ServeHTTP(rw, req)

--- a/v3/version.go
+++ b/v3/version.go
@@ -38,7 +38,7 @@ func (v *versionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request, ne
 
 	// Add the requested API version to response headers (useful for clients
 	// when a default version was negotiated)
-	rw.Header().Add(HeaderSpirentApiVersion, strconv.Itoa(version))
+	AddHeader(rw, HeaderSpirentApiVersion, strconv.Itoa(version))
 
 	// Add the requested API version to handler context so that downstream
 	// handlers can dispatch correctly

--- a/v3/version_test.go
+++ b/v3/version_test.go
@@ -12,7 +12,7 @@ func TestNonPositiveApiVersionConstraint(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Add(HeaderSpirentApiVersion, "0")
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	v := &versionHandler{
 		minVersion: 2,
@@ -28,7 +28,7 @@ func TestMinApiVersionConstraint(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Add(HeaderSpirentApiVersion, "1")
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	v := &versionHandler{
 		minVersion: 2,
@@ -44,7 +44,7 @@ func TestMaxApiVersionConstraint(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Add(HeaderSpirentApiVersion, "43")
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	v := &versionHandler{
 		minVersion: 2,
@@ -61,7 +61,7 @@ func TestApiVersionContext(t *testing.T) {
 	req.Header.Add(HeaderSpirentApiVersion, "1")
 	req = req.WithContext(withHandlerDetails(req.Context(), &handlerDetails{}))
 	rw := httptest.NewRecorder()
-	rw.Header().Set(HeaderContentType, ContentTypeJson)
+	SetHeader(rw, HeaderContentType, ContentTypeJson)
 
 	v := &versionHandler{
 		minVersion: 1,


### PR DESCRIPTION
1. Added `AddHeader` and `SetHeader` for sanitizing the value before adding to http response writer