### PR TITLE
add Service.SetGetCertificateHandler() function

### DIFF
--- a/v3/listener.go
+++ b/v3/listener.go
@@ -89,3 +89,17 @@ func NewStoppableTLSListener(addr string, keepalives bool, certFile string, keyF
 	}
 	return tls.NewListener(stl, tlsConfig), nil
 }
+
+func NewStoppableTLSGetCertificateListener(addr string, keepalives bool,
+	getCertificateHandler func(*tls.ClientHelloInfo) (*tls.Certificate, error)) (net.Listener, error) {
+	tlsConfig := &tls.Config{
+		NextProtos:     []string{"http/1.1", "h2"},
+		GetCertificate: getCertificateHandler,
+	}
+
+	stl, err := NewStoppableTCPListener(addr, keepalives)
+	if err != nil {
+		return nil, err
+	}
+	return tls.NewListener(stl, tlsConfig), nil
+}


### PR DESCRIPTION
This function is used to set the tls.Config.GetCertificate handler function.

Services can use this function to provide the TLS certificate and update it if needed (e.g. files were modified).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SpirentOrion/luddite/82)
<!-- Reviewable:end -->
