### PR TITLE
TMV-2856: Fix Luddite TLS issue

### DIFF
--- a/v3/certificate_loader.go
+++ b/v3/certificate_loader.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultWatcherScanFrequency = 1 * time.Minute
+	defaultWatcherScanMinutes = 5
 )
 
 type CertificateLoader interface {
@@ -37,13 +37,13 @@ func NewCertificateLoader(config *ServiceConfig, logger *log.Logger) (Certificat
 	if err := cl.storeCertificate(); err != nil {
 		return nil, err
 	}
-	if config.Transport.ReloadOnUpdate {
+	if !config.Transport.CertWatcher.Disabled {
 		cl.watcher = NewWatcher(logger, cl.certFilePath, cl.keyFilePath)
-		frequency := config.Transport.ReloadScanFrequency
-		if frequency == 0 {
-			frequency = defaultWatcherScanFrequency
+		scanMinutes := config.Transport.CertWatcher.ScanMinutes
+		if scanMinutes == 0 {
+			scanMinutes = defaultWatcherScanMinutes
 		}
-		cl.watcher.Watch(cl.storeCertificate, frequency)
+		cl.watcher.Watch(cl.storeCertificate, time.Duration(scanMinutes)*time.Minute)
 	}
 	return cl, nil
 }

--- a/v3/certificate_loader.go
+++ b/v3/certificate_loader.go
@@ -3,28 +3,28 @@ package luddite
 import (
 	"crypto/tls"
 	"fmt"
-	"path"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	dedupDelay = 5 * time.Second
+	defaultWatcherScanFrequency = 1 * time.Minute
 )
 
 type CertificateLoader interface {
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
-	Close() error
+	Close()
 }
 
 type certLoader struct {
 	cert         atomic.Pointer[tls.Certificate]
 	certFilePath string
 	keyFilePath  string
-	watcher      *fsnotify.Watcher
+	watcher      Watcher
 	log          *log.Logger
 }
 
@@ -38,9 +38,12 @@ func NewCertificateLoader(config *ServiceConfig, logger *log.Logger) (Certificat
 		return nil, err
 	}
 	if config.Transport.ReloadOnUpdate {
-		if err := cl.watch(); err != nil {
-			return nil, err
+		cl.watcher = NewWatcher(logger, cl.certFilePath, cl.keyFilePath)
+		frequency := config.Transport.ReloadScanFrequency
+		if frequency == 0 {
+			frequency = defaultWatcherScanFrequency
 		}
+		cl.watcher.Watch(cl.storeCertificate, frequency)
 	}
 	return cl, nil
 }
@@ -59,86 +62,113 @@ func (l *certLoader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, e
 	return l.cert.Load(), nil
 }
 
-func (l *certLoader) Close() error {
+func (l *certLoader) Close() {
 	if l.watcher != nil {
-		return l.watcher.Close()
+		l.watcher.Close()
 	}
-	return nil
+	return
 }
 
-func (l *certLoader) watch() error {
-	w, err := fsnotify.NewWatcher()
-	if err != nil {
-		return err
-	}
-	l.watcher = w
-
-	certFileDir := path.Dir(l.certFilePath)
-	if err = l.watcher.Add(certFileDir); err != nil {
-		return fmt.Errorf("error adding dir '%s' to watcher: %s", certFileDir, err.Error())
-	}
-	l.log.Debugf("cert directory '%s' added to watcher", certFileDir)
-
-	keyFileDir := path.Dir(l.keyFilePath)
-	if keyFileDir != certFileDir {
-		if err = l.watcher.Add(keyFileDir); err != nil {
-			return fmt.Errorf("error adding dir '%s' to watcher: %s", keyFileDir, err.Error())
-		}
-		l.log.Debugf("key directory '%s' added to watcher", keyFileDir)
-	}
-
-	go l.fsWatch(l.watcher, l.certFilePath, l.keyFilePath)
-
-	return nil
+type Watcher interface {
+	Close()
+	Watch(loadCertCallback func() error, frequency time.Duration)
 }
 
-func (l *certLoader) fsWatch(watcher *fsnotify.Watcher, filenames ...string) {
-	var timer *time.Timer
-	defer func() {
-		if timer != nil {
-			timer.Stop()
+type watcher struct {
+	watchPaths WatchPaths
+	done       chan interface{}
+	log        *log.Logger
+}
+
+func NewWatcher(logger *log.Logger, paths ...string) Watcher {
+	return &watcher{
+		watchPaths: NewWatchPaths(logger, paths...),
+		done:       make(chan interface{}),
+		log:        logger,
+	}
+}
+
+func (w *watcher) Close() {
+	close(w.done)
+}
+
+func (w *watcher) Watch(loadCertCallback func() error, frequency time.Duration) {
+	go func() {
+		ticker := time.NewTicker(frequency)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-w.done:
+				return
+			case <-ticker.C:
+				if w.watchPaths.Update() {
+					if err := loadCertCallback(); err != nil {
+						w.log.WithError(err).Error("error reloading certificate")
+					}
+				}
+			}
 		}
 	}()
-	for {
-		select {
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return
-			}
-			if updated := l.handleFsEvent(event, filenames...); updated {
-				// N.B. process the event after a delay to avoid duplicates when both files are written
-				timer = setDeDupTimer(timer, func() {
-					if err := l.storeCertificate(); err != nil {
-						l.log.WithError(err).Error("error reloading certificate")
-					}
-				})
-			}
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return
-			}
-			l.log.WithError(err).Error("certificate watcher error")
-		}
-	}
 }
 
-func (l *certLoader) handleFsEvent(event fsnotify.Event, files ...string) bool {
-	if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-		for _, fn := range files {
-			if path.Base(event.Name) == path.Base(fn) {
-				l.log.Debugf("file '%s' was updated", fn)
-				return true
-			}
-		}
+type WatchPaths []WatchPath
+
+func NewWatchPaths(logger *log.Logger, paths ...string) WatchPaths {
+	wps := make(WatchPaths, len(paths))
+	for i, fp := range paths {
+		wps[i] = NewWatchPath(fp, logger)
 	}
-	return false
+	return wps
 }
 
-func setDeDupTimer(timer *time.Timer, callback func()) *time.Timer {
-	if timer == nil {
-		timer = time.AfterFunc(dedupDelay, callback)
-	} else {
-		timer.Reset(dedupDelay)
+func (wps WatchPaths) Update() (modified bool) {
+	for _, wp := range wps {
+		modified = modified || wp.Update()
 	}
-	return timer
+	return
+}
+
+type WatchPath interface {
+	Update() bool
+}
+
+type watchPath struct {
+	path    string
+	modTime time.Time
+	log     *log.Logger
+}
+
+func NewWatchPath(p string, logger *log.Logger) WatchPath {
+	wp := &watchPath{
+		path: p,
+		log:  logger,
+	}
+	wp.Update()
+	return wp
+}
+
+func (wp *watchPath) Update() (modified bool) {
+	if latestModTime := wp.latestModTime(); !latestModTime.IsZero() {
+		if modified = wp.modTime.IsZero() || !wp.modTime.Equal(latestModTime); modified {
+			wp.modTime = latestModTime
+			wp.log.Debugf("mod time stored for path '%s'", wp.path)
+		}
+	}
+	return
+}
+
+func (wp *watchPath) latestModTime() (lmt time.Time) {
+	f, err := filepath.EvalSymlinks(wp.path)
+	if err != nil {
+		wp.log.WithError(err).Errorf("failed to eval file path '%s'", wp.path)
+		return
+	}
+	fi, err := os.Stat(f)
+	if err != nil {
+		wp.log.WithError(err).Errorf("failed to get file info '%s'", f)
+		return
+	}
+	lmt = fi.ModTime().UTC()
+	wp.log.Debugf("got file info '%s': '%s'", f, lmt)
+	return
 }

--- a/v3/config.go
+++ b/v3/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -134,6 +135,9 @@ type ServiceConfig struct {
 
 		// ReloadOnUpdate monitor CertFilePath and KeyFilePath for changes, reload automatically
 		ReloadOnUpdate bool `yaml:"reload_on_update"`
+
+		// ReloadScanFrequency when monitoring for file changes, how often to scan for changes (default is 1m)
+		ReloadScanFrequency time.Duration `yaml:"reload_scan_frequency,omitempty"`
 	}
 
 	Version struct {

--- a/v3/config.go
+++ b/v3/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -133,11 +132,13 @@ type ServiceConfig struct {
 		// KeyFilePath sets the path to the server's key file.
 		KeyFilePath string `yaml:"key_file_path"`
 
-		// ReloadOnUpdate monitor CertFilePath and KeyFilePath for changes, reload automatically
-		ReloadOnUpdate bool `yaml:"reload_on_update"`
-
-		// ReloadScanFrequency when monitoring for file changes, how often to scan for changes (default is 1m)
-		ReloadScanFrequency time.Duration `yaml:"reload_scan_frequency,omitempty"`
+		// CertWatcher monitor CertFilePath and KeyFilePath for changes
+		CertWatcher struct {
+			// Disabled disable monitoring and automatic reloads when cert/key files are changed
+			Disabled bool `yaml:"disabled,omitempty"`
+			// ScanMinutes when monitoring for file changes, how often to scan for changes (default is 5)
+			ScanMinutes int `yaml:"scan_minutes,omitempty"`
+		} `yaml:"cert_watcher"`
 	}
 
 	Version struct {

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/K-Phoen/negotiation v0.0.0-20160529191006-5f2c7e65d11c
 	github.com/dimfeld/httptreemux v5.0.1+incompatible
-	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gorilla/schema v1.3.0
 	github.com/opentracing/basictracer-go v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -36,8 +36,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
 github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/v3/service.go
+++ b/v3/service.go
@@ -400,9 +400,7 @@ func (s *Service) run() error {
 		if certificateLoader, err = NewCertificateLoader(s.config, s.Logger()); err != nil {
 			return err
 		}
-		defer func() {
-			_ = certificateLoader.Close()
-		}()
+		defer certificateLoader.Close()
 		s.defaultLogger.Debugf("HTTPS listening on %s", s.config.Addr)
 		if listener, err = NewStoppableTLSListener(s.config.Addr, true, certificateLoader.GetCertificate); err != nil {
 			return err


### PR DESCRIPTION
when `tls.reload_on_update=true` the fs events were not recognized when the configured cert file paths were symlinks. 
* removing the filename filter from event processing could easily result in continuous reloads (seen during testing)
* also seen in testing, on osx `fsnotify` can create an event storm which can crash process/machine

solution:
* eval symlinks in the configured file paths and use target `modtime` to detect changes.
* removed `fsnotify` and replaced with a simple goroutine that stats the `cert` and `key` files to detect changes and reloads when necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SpirentOrion/luddite/84)
<!-- Reviewable:end -->
